### PR TITLE
added IOError exception to support netcdf4 v 1.4.4

### DIFF
--- a/src/ocgis/api/request/driver/nc.py
+++ b/src/ocgis/api/request/driver/nc.py
@@ -49,7 +49,7 @@ class DriverNetcdf(AbstractDriver):
     def open(self):
         try:
             ret = nc.Dataset(self.rd.uri, 'r')
-        except (TypeError, RuntimeError):
+        except (TypeError, RuntimeError, IOError):
             try:
                 ret = nc.MFDataset(self.rd.uri)
             except KeyError as e:


### PR DESCRIPTION
There is one error in the test suite but I can't tell if its related or not. 

```
======================================================================
ERROR: test_calc (ocgis.test.test_simple.test_simple.TestSimple)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/dhuard/src/ocgis.git/src/ocgis/test/test_simple/test_simple.py", line 590, in test_calc
    ret = self.get_ret(kwds={'calc': calc, 'calc_grouping': group, 'aggregate': True, 'calc_raw': calc_raw})
  File "/home/dhuard/src/ocgis.git/src/ocgis/test/test_simple/test_simple.py", line 91, in get_ret
    ret = OcgInterpreter(ops).execute()
  File "/home/dhuard/src/ocgis.git/src/ocgis/api/interpreter.py", line 125, in execute
    ret = conv.write()
  File "/home/dhuard/src/ocgis.git/src/ocgis/conv/numpy_.py", line 14, in write
    for coll in self:
  File "/home/dhuard/src/ocgis.git/src/ocgis/conv/numpy_.py", line 9, in __iter__
    for coll in self.colls:
  File "/home/dhuard/src/ocgis.git/src/ocgis/api/subset.py", line 75, in __iter__
    for coll in self._iter_collections_():
  File "/home/dhuard/src/ocgis.git/src/ocgis/api/subset.py", line 139, in _iter_collections_
    coll = self.cengine.execute(coll, file_only=self.ops.file_only, tgds=tgds)
  File "/home/dhuard/src/ocgis.git/src/ocgis/calc/engine.py", line 138, in execute
    out_vc = function.execute()
  File "/home/dhuard/src/ocgis.git/src/ocgis/calc/base.py", line 154, in execute
    self._execute_()
  File "/home/dhuard/src/ocgis.git/src/ocgis/calc/base.py", line 627, in _execute_
    fill = self._get_temporal_agg_fill_(value, shp_fill=shp_fill)
  File "/home/dhuard/src/ocgis.git/src/ocgis/calc/base.py", line 433, in _get_temporal_agg_fill_
    fill[ir, it, il, :, :] = self.aggregate_spatial(cc, weights)
  File "/home/dhuard/src/ocgis.git/src/ocgis/calc/base.py", line 119, in aggregate_spatial
    ret = np.ma.average(values, weights=weights)
  File "/home/dhuard/.miniconda3/envs/OPG2/lib/python2.7/site-packages/numpy/ma/extras.py", line 536, in average
    "Axis must be specified when shapes of a and weights "
TypeError: Axis must be specified when shapes of a and weights differ.
```