### PR TITLE
porting to gdal ogr

### DIFF
--- a/src/ocgis/spatial/geom_cabinet.py
+++ b/src/ocgis/spatial/geom_cabinet.py
@@ -2,7 +2,7 @@ import os
 from collections import OrderedDict
 
 import fiona
-import ogr
+from osgeo import ogr
 from ocgis import env
 from ocgis.collection.field import Field
 from ocgis.util.helpers import get_formatted_slice


### PR DESCRIPTION
I was trying to run your test after the setup:

`python -c "from ocgis.test import run_simple; run_simple(verbose=False)"`

And this gave me an `ModuleNotFoundError: No module named 'ogr'` So I believe adding `from osgeo import ogr` could fix it. Thanks in advance
David